### PR TITLE
Remove the maven warning about file encoding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <javax.jstl.version>1.2</javax.jstl.version>
     <spring.version>3.0.5.RELEASE</spring.version>
     <project.build.finalName>SHOGun</project.build.finalName>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   
   <repositories>


### PR DESCRIPTION
Specify encoding in `pom.xml` to get rid of warnings like

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```

Now maven simply informs

```
[INFO] Using 'UTF-8' encoding to copy filtered resources.
```
