### PR TITLE
Let the updateEntity method return the persistant object.

### DIFF
--- a/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
+++ b/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
@@ -523,10 +523,10 @@ public class DatabaseDao {
 	 */
 	public Object updateEntity(String entityClass, Object objToUpdate) {
 		
-		this.sessionFactory.getCurrentSession().merge(entityClass, objToUpdate);
+		Object updatedObject = this.sessionFactory.getCurrentSession().merge(entityClass, objToUpdate);
 		this.sessionFactory.getCurrentSession().flush();
 		
-		return objToUpdate;
+		return updatedObject;
 	}
 	
 	/**


### PR DESCRIPTION
Let the updateEntity method return the persistant object, instead of passing back the object of the request.
