### PR TITLE
Introduced a flag enabling/disabling the DB-init-script

### DIFF
--- a/src/main/java/de/terrestris/shogun/init/DatabaseContentInitializer.java
+++ b/src/main/java/de/terrestris/shogun/init/DatabaseContentInitializer.java
@@ -40,6 +40,11 @@ public class DatabaseContentInitializer {
 	 */
 	private static Logger LOGGER = Logger
 			.getLogger(DatabaseContentInitializer.class);
+	
+	/** 
+	 * flag symbolizing if the database will be modified by this class 
+	 */
+	private Boolean databaseInitializationEnabled;
 
 	/**
 	 * a list of module objects for this applications
@@ -107,19 +112,23 @@ public class DatabaseContentInitializer {
 	 * Delegated the tasks to fill the database due to config
 	 */
 	public void initializeDatabaseContent() {
-		LOGGER.info("Initializing database content on servlet init.");
 
-		try {
-			this.persistantStdWmsLayer = this.createStandardWmsMapLayer();
-			this.createAvailableRoles();
-			this.createAvailableModules();
-			this.persistantStdMapConfig = this.createAvailableMapConfig();
-			this.createDefaultGroup();
-			this.createSuperAdmin();
-			this.createAnonymousUser(this.persistantStdWmsLayer, this.persistantStdMapConfig, null);
-		} catch (Exception e) {
-			LOGGER.error("Caught exception '" + e.getClass().getSimpleName()
-					+ "':", e);
+		if (this.databaseInitializationEnabled == true) {
+			
+			LOGGER.info("Initializing database content on servlet init.");
+
+			try {
+				this.persistantStdWmsLayer = this.createStandardWmsMapLayer();
+				this.createAvailableRoles();
+				this.createAvailableModules();
+				this.persistantStdMapConfig = this.createAvailableMapConfig();
+				this.createDefaultGroup();
+				this.createSuperAdmin();
+				this.createAnonymousUser(this.persistantStdWmsLayer, this.persistantStdMapConfig, null);
+			} catch (Exception e) {
+				LOGGER.error("Caught exception '" + e.getClass().getSimpleName()
+						+ "':", e);
+			}
 		}
 	}
 
@@ -418,6 +427,16 @@ public class DatabaseContentInitializer {
 		}
 
 		return target;
+	}
+	
+	/**
+	 * @param shogunDatabaseInitializationEnabled 
+	 * 			the shogunDatabaseInitializationEnabled to set
+	 */
+	@Autowired
+	public void setDatabaseInitializationEnabled(
+			Boolean databaseInitializationEnabled) {
+		this.databaseInitializationEnabled = databaseInitializationEnabled;
 	}
 
 	/**

--- a/src/main/webapp/WEB-INF/spring/initialize-beans.xml
+++ b/src/main/webapp/WEB-INF/spring/initialize-beans.xml
@@ -6,6 +6,11 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
 		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+		
+	<!-- flag for enabling/disabling the automatic init-script on startup -->
+	<bean id="databaseInitializationEnabled" class="java.lang.Boolean">
+		<constructor-arg value="true"></constructor-arg>
+	</bean>
 
 	<!-- A bean to be used by the initialize database bean that represents the 
 		standard WmsMapLayer object, that e.g. the anonymous user will get. -->


### PR DESCRIPTION
A flag in the configuration makes the startup of the database initialization
while startup process configurable.
