### PR TITLE
Add qualifier annotation to autowired annotation.

### DIFF
--- a/src/main/java/de/terrestris/shogun/init/DatabaseContentInitializer.java
+++ b/src/main/java/de/terrestris/shogun/init/DatabaseContentInitializer.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.encoding.Md5PasswordEncoder;
 import org.springframework.security.authentication.encoding.PasswordEncoder;
 
@@ -434,6 +435,7 @@ public class DatabaseContentInitializer {
 	 * 			the shogunDatabaseInitializationEnabled to set
 	 */
 	@Autowired
+	@Qualifier("databaseInitializationEnabled")
 	public void setDatabaseInitializationEnabled(
 			Boolean databaseInitializationEnabled) {
 		this.databaseInitializationEnabled = databaseInitializationEnabled;


### PR DESCRIPTION
This allows subclasses of `DatabaseContentInitializer` to introduce more beans of type `java.lang.Boolean`.

We should also consider switching to the `@Resource`-annotation (see e.g. here http://stackoverflow.com/a/4462494/860988) but only if we do it everywhere.

Please review.
