### PR TITLE
Parse formatted date strings when deserializing JSON.

### DIFF
--- a/src/main/java/de/terrestris/shogun/deserializer/DateDeserializer.java
+++ b/src/main/java/de/terrestris/shogun/deserializer/DateDeserializer.java
@@ -1,50 +1,116 @@
 package de.terrestris.shogun.deserializer;
 
 import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.apache.log4j.Logger;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.map.DeserializationContext;
 import org.codehaus.jackson.map.JsonDeserializer;
 
 /**
+ * Class responsible for deserializing a date.
  *
- * Class responsible for deserializing a date
- * Makes a Date object out of an UNIX timestamp
+ * Makes a Date object out of an UNIX timestamp or a formatted date string.
  *
  * @author terrestris GmbH & Co. KG
  *
  */
 public class DateDeserializer extends JsonDeserializer<Date> {
 
+	private static Logger LOGGER = Logger.getLogger(DateDeserializer.class);
+
+	private static String DATE_FORMAT = "dd.MM.yyyy HH:mm:ss";
+
+	private static String[] FORMATTED_DATE_HINT_CHARS = {":", "."};
+
 	/**
-	 * Overwrite the deserializer for date strings in the for of a
-	 * unix timestamp (1293836400)
+	 * Does some simple checks to determine whether we we're passed a formatted
+	 * date string. This is far from being complete, but does the job for the
+	 * current purposes.
 	 *
-	 * TODO exception handling
+	 * @param jsonStr
+	 * @return Whether the passed string looked like a formatted date.
+	 */
+	public static boolean looksLikeFormattedDateString(String jsonStr) {
+		boolean looksLikeFormattedDate = false;
+		int formattedLen = DATE_FORMAT.length();
+
+		if (jsonStr != null) {
+			if(jsonStr.length() == formattedLen) {
+				for (int idx = 0; idx < FORMATTED_DATE_HINT_CHARS.length; idx++) {
+					if(!jsonStr.contains(FORMATTED_DATE_HINT_CHARS[idx])){
+						looksLikeFormattedDate = false;
+						break;
+					} else {
+						looksLikeFormattedDate = true;
+					}
+				}
+			}
+		}
+
+		return looksLikeFormattedDate;
+	}
+
+	/**
+	 * This method tries to convert a passed date string into a date.
+	 *
+	 * Currently only strings formatted as <code>dd.MM.yyyy HH:mm:ss</code> are
+	 * supported.
+	 *
+	 * @param jsonStr
+	 * @return a <code>Date</code>-object or null.
+	 */
+	public static Date parseCommonlyFormattedDate(String jsonStr) {
+		SimpleDateFormat parserSDF = new SimpleDateFormat(DATE_FORMAT);
+		parserSDF.setLenient(false);
+
+		Date parsedDate = null;
+
+		String failNotice = "Failed to parse string '" + jsonStr +
+				"' with format '" + DATE_FORMAT + "'";
+		try {
+			parsedDate = parserSDF.parse(jsonStr);
+		} catch (ParseException e) {
+			LOGGER.error(failNotice + ": " + e.getMessage());
+		}
+		if (parsedDate == null) {
+			LOGGER.info(failNotice);
+		}
+		return parsedDate;
+	}
+
+	/**
+	 * Overwrite the deserializer for date strings in the form of a
+	 * unix timestamp (1293836400).
+	 *
+	 * This method will also try to interpret strings like "30.04.2013 13:43:55"
+	 * as dates.
 	 */
 	@Override
 	public Date deserialize(JsonParser jsonParser, DeserializationContext context)
 			throws IOException, JsonProcessingException {
 
-		Date d = null;
+		Date deserializedDate = null;
+		String s = jsonParser.getText();
 
-		try {
-
-			String s = jsonParser.getText();
-
-			// 1293836400
-			Long l = new Long(s);
-			d = new Date(l);
-
+		if ( DateDeserializer.looksLikeFormattedDateString(s) ) {
+			deserializedDate = DateDeserializer.parseCommonlyFormattedDate(s);
+		} else {
+			String failNotice = "Failed to interpret string '" + s +
+					"' as java.lang.Long. That string did not look like a " +
+					"formatted date either.";
+			try {
+				Long number = new Long(s);
+				deserializedDate = new Date(number);
+			} catch (NumberFormatException e) {
+				LOGGER.error(failNotice + " : " + e.getMessage());
+			}
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-		}
-
-		return d;
-
+		return deserializedDate;
 	}
 
 }

--- a/src/test/java/de/terrestris/shogun/DateDeserializerTest.java
+++ b/src/test/java/de/terrestris/shogun/DateDeserializerTest.java
@@ -1,0 +1,98 @@
+package de.terrestris.shogun;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.terrestris.shogun.deserializer.DateDeserializer;
+
+
+/**
+ * Unit tests for the DateDeserializer class.
+ */
+public class DateDeserializerTest {
+
+	String aNumber = "1293836400";
+	String correctlyFormattedDate = "30.04.2013 13:43:55";
+	String correctlyFormattedDateUnparseable = "75.15.7017 47:61:31";
+	String incorrectlyFormattedDate = "2013-04-30 13:43:55";
+	String nonsense = "Humpty.Dumpty:12345";
+
+	SimpleDateFormat compareFormat = new SimpleDateFormat("dd.MM.yyyy HH:mm:ss");
+
+	/**
+	 * Check whether strings passed to the static looksLikeFormattedDateString
+	 * method are detected as dates when expected.
+	 */
+	@Test
+	public void testFormattedDateDetection() {
+		Assert.assertFalse(
+			"'" + aNumber + "' is not detected as formatted date.",
+			DateDeserializer.looksLikeFormattedDateString(aNumber)
+		);
+
+		Assert.assertTrue(
+			"'" + correctlyFormattedDate + "' is detected as formatted date.",
+			DateDeserializer.looksLikeFormattedDateString(correctlyFormattedDate)
+		);
+
+		Assert.assertTrue(
+			"'" + correctlyFormattedDateUnparseable + "' is detected as formatted date.",
+			DateDeserializer.looksLikeFormattedDateString(correctlyFormattedDateUnparseable)
+		);
+
+		Assert.assertFalse(
+			"'" + incorrectlyFormattedDate + "' is not detected as formatted date.",
+			DateDeserializer.looksLikeFormattedDateString(incorrectlyFormattedDate)
+		);
+
+		Assert.assertTrue(
+			"'" + nonsense + "' is not detected as formatted date.",
+			DateDeserializer.looksLikeFormattedDateString(nonsense)
+		);
+	}
+
+	/**
+	 * Check whether parsing works correctly when given correctly formatted
+	 * string with sane content and returns null otherwise.
+	 */
+	@Test
+	public void testDeserialisation() {
+		Date dateFromNumber = DateDeserializer.parseCommonlyFormattedDate(aNumber);
+		Date correctDate = DateDeserializer.parseCommonlyFormattedDate(correctlyFormattedDate);
+		Date correctlyFormattedUnparseable = DateDeserializer.parseCommonlyFormattedDate(correctlyFormattedDateUnparseable);
+		Date incorrectlyFormatted = DateDeserializer.parseCommonlyFormattedDate(incorrectlyFormattedDate);
+		Date nonsenseDate = DateDeserializer.parseCommonlyFormattedDate(nonsense);
+
+		Assert.assertNull(
+			"Parsing '" + aNumber + "' as formatted date does return null.",
+			dateFromNumber
+		);
+		Assert.assertNull(
+			"Parsing '" + correctlyFormattedDateUnparseable + "' as formatted date does return null.",
+			correctlyFormattedUnparseable
+		);
+		Assert.assertNull(
+			"Parsing '" + incorrectlyFormattedDate + "' as formatted date does return null.",
+			incorrectlyFormatted
+		);
+		Assert.assertNull(
+			"Parsing '" + nonsense + "' as formatted date does return null.",
+			nonsenseDate
+		);
+
+		// this one should work
+		Assert.assertNotNull(
+			"Parsing '" + correctlyFormattedDate + "' as formatted date does not return null.",
+			correctDate
+		);
+		Assert.assertEquals(
+			"Parsing '" + correctlyFormattedDate + "' as formatted date returns correct date.",
+			compareFormat.format(correctDate),
+			correctlyFormattedDate
+		);
+
+	}
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+# disable logging for tests.
+log4j.rootLogger=OFF, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - %m%n


### PR DESCRIPTION
When deserializing JSON strings sent from clients, we usually accept numeric
timestamps for date columns. With this change we can now also accept strings
in a common date format.

The current implementation will successfully parse dates passed as e.g.
`30.04.2013 13:43:55` because the `java.text.SimpleDateFormat` used is
`dd.MM.yyyy HH:mm:ss`. Future implementations might enhance this approach
with more sophisticated methods to both check whether we are deserializing a
formatted date and more formats which are tried in order to transform a string
to a proper date.

Please review.
