### PR TITLE
Enhanced startup performance

### DIFF
--- a/src/main/webapp/WEB-INF/spring/app-config.xml
+++ b/src/main/webapp/WEB-INF/spring/app-config.xml
@@ -12,28 +12,19 @@
 
 	<!-- Scans the classpath of this application for @Components to deploy as beans -->
 	<context:component-scan base-package="de.terrestris.shogun" />
-	
-	<!-- Configures the @Controller programming model -->
-	<mvc:annotation-driven />
-	
+
 	<!-- enable post pre annotations -->	
 	<sec:global-method-security pre-post-annotations="enabled"/>
-	
-	<!-- misc - internal view resolver -->
-	<bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
-		<property name="viewClass" value="org.springframework.web.servlet.view.JstlView"/>
-		<property name="suffix" value=".jsp"/>
-	</bean>
 
 	<!-- Configures the initialization script, 
 	     for example a standard user to be created on first startup
 	-->
 	<import resource="initialize-beans.xml" />
-	
+
 	<!-- Configures Hibernate - database configuration -->
 	<import resource="db-config.xml" />
-	
+
 	<!-- Configures the security mechanism -->
 	<import resource="applicationContext-security.xml" />
-	
+
 </beans>

--- a/src/main/webapp/WEB-INF/spring/shogun-config.xml
+++ b/src/main/webapp/WEB-INF/spring/shogun-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:sec="http://www.springframework.org/schema/security"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd">
+
+    <!-- Scans the classpath of this application for @Components to deploy as beans -->
+    <context:component-scan base-package="de.terrestris.shogun" />
+
+    <!-- Configures the @Controller programming model -->
+    <mvc:annotation-driven />
+
+    <!-- misc - internal view resolver -->
+<!--     <bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
+        <property name="viewClass" value="org.springframework.web.servlet.view.JstlView"/>
+        <property name="suffix" value=".jsp"/>
+    </bean> -->
+
+</beans>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -33,7 +33,7 @@
 		<init-param>
 			<param-name>contextConfigLocation</param-name>
 			<param-value>
-				/WEB-INF/spring/app-config.xml
+				/WEB-INF/spring/shogun-config.xml
 			</param-value>
 		</init-param>
 		<load-on-startup>1</load-on-startup>


### PR DESCRIPTION
Enhanced startup performance due to creation of a separate contextConfig for the shogun-servlet (shogun-config.xml). the core config
(app-config.xml) wont be used as the core and servlet-config anymore.
This way the hibernate-schema-handling will only be executed once and
not twice. This noticeable enhances the startup time when e.g. using
hibernate.hbm2ddl.auto=create
