### PR TITLE
Increased the size of the LAYERS-column of the WmsMapLayer-class

### DIFF
--- a/src/main/java/de/terrestris/shogun/model/WmsMapLayer.java
+++ b/src/main/java/de/terrestris/shogun/model/WmsMapLayer.java
@@ -47,7 +47,7 @@ public class WmsMapLayer extends MapLayer {
 	/**
 	 * @return the layers
 	 */
-	@Column(name = "LAYERS", nullable = false)
+	@Column(name = "LAYERS", nullable = false, length = 2048)
 	public String getLayers() {
 		return layers;
 	}


### PR DESCRIPTION
Increased the size of the LAYERS-column of the WmsMapLayer-class. This way it will be possible to save strings that are larger than the default size (of e.g. 255), which is e.g. necessary when saving a WmsMapLayer with a long comma-separated LAYERS-argument.
