### PR TITLE
Improved the config of the whole project

### DIFF
--- a/src/main/webapp/WEB-INF/spring/app-config.xml
+++ b/src/main/webapp/WEB-INF/spring/app-config.xml
@@ -10,31 +10,22 @@
 		http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
 		http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd">
 
-	<!-- Scans the classpath of this application for @Components to deploy as beans -->
-	<context:component-scan base-package="de.terrestris.shogun" />
-
-	<!-- Configures the @Controller programming model -->
-	<mvc:annotation-driven />
-
-	<!-- misc - internal view resolver -->
-	<!--  we dont use spring MVC-views -->
-<!-- <bean id="viewResolver" class="org.springframework.web.servlet.view.InternalResourceViewResolver">
-		<property name="viewClass" value="org.springframework.web.servlet.view.JstlView"/>
-		<property name="suffix" value=".jsp"/>
-	</bean> -->
-
-	<!-- enable post pre annotations -->	
-	<sec:global-method-security pre-post-annotations="enabled"/>
-
-	<!-- Configures the initialization script, 
-		 for example a standard user to be created on first startup
+	<!-- This is the root application context configuration, which is declared in the web.xml.
+		 The context of any servlet declared in the web.xml will inherit from this context.
+		 http://syntx.co/languages-frameworks/difference-between-loading-context-via-dispatcherservlet-and-contextloaderlistener/
 	-->
-	<import resource="initialize-beans.xml" />
 
-	<!-- Configures Hibernate - database configuration -->
-	<import resource="db-config.xml" />
+	<!-- Scans the classpath of this application for @Components to deploy as beans -->
+	<context:component-scan base-package="de.terrestris">
+		<!--  We exclude all Controllers here,
+			  but access them in the child context of the shogun-servlet,
+			  which will inherit all the stuff declared in the web.xml
+			  root contextConfigLocation
+		-->
+		<context:exclude-filter expression="org.springframework.stereotype.Controller" type="annotation"/>
+	</context:component-scan>
 
-	<!-- Configures the security mechanism -->
-	<import resource="applicationContext-security.xml" />
+	<!-- enable post pre annotations -->
+	<sec:global-method-security pre-post-annotations="enabled"/>
 
 </beans>

--- a/src/main/webapp/WEB-INF/spring/shogun-config.xml
+++ b/src/main/webapp/WEB-INF/spring/shogun-config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:sec="http://www.springframework.org/schema/security"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd
+        http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-3.0.xsd">
+
+    <!-- This is the context configuration for the shogun-DispatcherServlet
+         defined in the web.xml. This context will inherit from the global contextConfigLocation,
+         which is also defined in the web.xml. This context will override everything
+         that matches the following context:component-scan base-package.
+         This means that we should make explicit and precise base-package declarations in this context.
+         Otherwise we would overwrite things from the parent context, e.g. Hibernate-TransactionManger 
+    -->
+    <context:component-scan base-package="de.terrestris.shogun.web" />
+
+    <!-- Configures the @Controller programming model -->
+    <mvc:annotation-driven />
+
+</beans>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -15,10 +15,21 @@
 		<listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
 	</listener>
 
+	<!-- Application Context -->
+	<!-- This Context is the root app context.
+		 The context of a servlet (e.g. the following shogun-servlet)
+		 will inherit from this context and have access to the stuff
+		 defined here, e.g. Hibernate-TransactionManger from db-config.
+		 see e.g. http://syntx.co/languages-frameworks/difference-between-loading-context-via-dispatcherservlet-and-contextloaderlistener/
+		 for more information.
+	-->
 	<context-param>
 		<param-name>contextConfigLocation</param-name>
 		<param-value>
 			/WEB-INF/spring/app-config.xml
+			/WEB-INF/spring/db-config.xml
+			/WEB-INF/spring/applicationContext-security.xml
+			/WEB-INF/spring/initialize-beans.xml
 		</param-value>
 	</context-param>
 	<listener>
@@ -37,13 +48,14 @@
 	</listener>
 	-->
 
+	<!-- Shogun-Servlet -->
 	<servlet>
 		<servlet-name>shogun</servlet-name>
 		<servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
 		<init-param>
 			<param-name>contextConfigLocation</param-name>
 			<param-value>
-				/WEB-INF/spring/app-config.xml
+				/WEB-INF/spring/shogun-config.xml
 			</param-value>
 		</init-param>
 		<load-on-startup>1</load-on-startup>
@@ -53,7 +65,6 @@
 		<servlet-name>shogun</servlet-name>
 		<url-pattern>*.action</url-pattern>
 	</servlet-mapping>
-	
 
 	<filter>
 		<filter-name>springSecurityFilterChain</filter-name>


### PR DESCRIPTION
 The root app context will be loaded in the web.xml now. The context of the shogun servlet will inherit from the root context, so that common stuff like dataSource or hibernate transaction manager will be available there. MVC-related things (e.g. scan for controllers or definition of views) will be declared in the child context of the servlet. See http://syntx.co/languages-frameworks/difference-between-loading-context-via-dispatcherservlet-and-contextloaderlistener/ for more information.
