### PR TITLE
Starting up with hibernate-ddl set to CREATE.

### DIFF
--- a/src/main/webapp/WEB-INF/spring/db-config.xml
+++ b/src/main/webapp/WEB-INF/spring/db-config.xml
@@ -90,7 +90,7 @@
 				<prop key="hibernate.dialect">org.hibernate.dialect.H2Dialect</prop>
 				<!-- <prop key="hibernate.dialect">org.hibernate.dialect.DerbyDialect</prop> -->
 				<prop key="hibernate.show_sql">false</prop>
-				<prop key="hibernate.hbm2ddl.auto">update</prop>
+				<prop key="hibernate.hbm2ddl.auto">create</prop>
 			</props>
 		</property>
 	</bean>


### PR DESCRIPTION
I would suggest to use CREATE for the hbm2ddl-config, so that SHOGun will start up without any errors after a first checkout.
