### PR TITLE
Avoid cartesian products in `getEntitesByStringFields`.

### DIFF
--- a/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
+++ b/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
@@ -846,6 +846,10 @@ public class DatabaseDao {
 				criteria.add(Restrictions.ilike(fieldname, value));
 			}
 
+			// this ensures that no cartesian product is returned when
+			// having sub objects, e.g. User <-> Modules
+			criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
+
 			returnList = (List<T>) criteria.list();
 
 		} catch (Exception e) {


### PR DESCRIPTION
The other generic DAO methods all have

``` java
criteria.setResultTransformer(Criteria.DISTINCT_ROOT_ENTITY);
```

to avoid cartesian products when fetching database entites. The method `getEntitesByStringFields` lacked that line.

Please review.
