### PR TITLE
Avoiding LazyInitializationException when executing getUsers() or getModules()

### DIFF
--- a/src/main/java/de/terrestris/shogun/service/ShogunService.java
+++ b/src/main/java/de/terrestris/shogun/service/ShogunService.java
@@ -312,6 +312,10 @@ public class ShogunService extends AbstractShogunService {
 			throw new ShogunServiceException("No user found, who is logged in at the backend");
 		}
 
+		// fetch the modules within the transaction in order to prevent a LazyLoadingException
+		// while serializing the user object to JSON
+		user.getModules();
+
 		// create an data object containing an JS object for app and user
 		// as a sub object of the return object
 		Map<String, Object> appDataMap = new HashMap<String, Object>(2);


### PR DESCRIPTION
To prevent a LazyInitializationException when requesting the app-context
with a logged in user the FetchMode of the Group-User- and the
Group-Module-relationship is changed to EAGER.
