### PR TITLE
Secure getAppContext only by spring-security-XML

### DIFF
--- a/src/main/java/de/terrestris/shogun/service/ShogunService.java
+++ b/src/main/java/de/terrestris/shogun/service/ShogunService.java
@@ -295,7 +295,6 @@ public class ShogunService extends AbstractShogunService {
 	 * @throws ShogunDatabaseAccessException
 	 * @throws Exception
 	 */
-	@PreAuthorize("hasAnyRole('ROLE_SUPERADMIN')")
 	@Transactional
 	public Map<String, Object> getAppContextBySession() throws ShogunServiceException, ShogunDatabaseAccessException {
 


### PR DESCRIPTION
The web service for requesting the app-context has been secured by the
applicationContext-security.xml and by a Java annotation within the
ShogunService class. These two mechanisms were in conflict to each other:
While the XML allowed anonymous-users to request the app-context it was
forbidden by the annotation. So anonymous-users could not request their
own app-context although it was explicitly allowed in the XML. A
consequence was that possible web-open applications could not been
loaded and started. This change removes the annotation so the web-service is
explicitly secured by the applicationContext-security.xml.

As discussed in the PSC-Meeting on 2014-06-11 (https://github.com/terrestris/shogun/wiki/PSC-Meeting-Notes---2014-06-11#ad-31-next-steps-shogun)
