### PR TITLE
Change FetchMode to enhance performance

### DIFF
--- a/src/main/java/de/terrestris/shogun/model/Group.java
+++ b/src/main/java/de/terrestris/shogun/model/Group.java
@@ -407,7 +407,7 @@ public class Group extends BaseModel{
 			@JoinColumn(name = "MAPLAYER_ID", nullable = false, updatable = false)
 		}
 	)
-	@Fetch(FetchMode.SUBSELECT)
+	@Fetch(FetchMode.JOIN)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
 	public Set<MapLayer> getMapLayers() {
 		return mapLayers;


### PR DESCRIPTION
We discovered heavy performance problems when a single group with (very) many MapLayers is being requested. In our case such a request took about 25 - 120 seconds, which is not acceptable.

The solutions seems to be easy: By changing the FetchMode at the MapLayer-relation from SUBSELECT to JOIN, the same requests will be answered in less than 5 seconds.

It would be great if anyone could review (and merge) this PR!
