### PR TITLE
Adapt column name for MS SQLServer compatibility

### DIFF
--- a/src/main/java/de/terrestris/shogun/model/LayerMetadata.java
+++ b/src/main/java/de/terrestris/shogun/model/LayerMetadata.java
@@ -35,7 +35,7 @@ public class LayerMetadata extends BaseModel {
 	/**
 	 * @return the key
 	 */
-	@Column(name="KEY")
+	@Column(name="KEY_STRING")
 	public String getKey() {
 		return key;
 	}


### PR DESCRIPTION
KEY seems to be a reserved word in SQLServer, so hibernate could not create the schema correctly.

Please review and merge!
