### PR TITLE
Enable criteria caching and update cache annotations

### DIFF
--- a/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
+++ b/src/main/java/de/terrestris/shogun/dao/DatabaseDao.java
@@ -137,7 +137,7 @@ public class DatabaseDao {
 		boolean isPlainModelRequest = (fields == null && ignoreFields == null);
 		Class<?> clazz = hibernateSortObject.getMainClass();
 
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 
 		// Fields
 		if (fields != null) {
@@ -554,7 +554,7 @@ public class DatabaseDao {
 			boolean groupDependent) {
 
 		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(
-				clazz);
+				clazz).setCacheable(true);
 
 		criteria.setProjection(Projections.distinct(Projections.projectionList()
 				.add(Projections.property(field), field)));
@@ -581,7 +581,7 @@ public class DatabaseDao {
 		boolean initializeDeeply = initializeDeep.length > 0 ? initializeDeep[0] : false;
 
 		Criteria criteria = null;
-		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 
 		// this ensures that no cartesian product is returned when
 		// having sub objects, e.g. User <-> Modules
@@ -607,7 +607,7 @@ public class DatabaseDao {
 
 		// get user ID of logged in User and check if there is the
 		// and it to the query as WHERE
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 		int userId = this.getUserIdFromSession();
 		criteria.add(Restrictions.eq("user_id", userId));
 		List<Object> records = criteria.list();
@@ -639,7 +639,7 @@ public class DatabaseDao {
 	public Object getEntityById(int id, Class<?> clazz, boolean initializeDeep) {
 
 		Criteria criteria = null;
-		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 		criteria.add(Restrictions.eq("id", id));
 		// we expect a single record or null
 		Object result = criteria.uniqueResult();
@@ -679,7 +679,7 @@ public class DatabaseDao {
 	public List<? extends Object> getEntitiesByIds(Object[] values, Class<?> clazz, String[] eagerfields) {
 		final int maxInElems = 999;
 		Criteria criteria = null;
-		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 
 		if (eagerfields != null && eagerfields.length > 0) {
 			for (String field : eagerfields) {
@@ -731,7 +731,7 @@ public class DatabaseDao {
 	public List<? extends Object> getEntitiesByExcludingIds(Object[] values, Class<?> clazz) {
 
 		Criteria criteria = null;
-		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 
 		if (values.length > 0) {
 			criteria.add(Restrictions.not(Restrictions.in("id", values)));
@@ -813,7 +813,7 @@ public class DatabaseDao {
 	 */
 	public List<Object> getEntitiesByIntegerField(Class<?> clazz, String fieldname, Integer value) {
 
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 		criteria.add(Restrictions.eq(fieldname, value));
 
 		// this ensures that no cartesian product is returned when
@@ -837,7 +837,7 @@ public class DatabaseDao {
 	public <T> List<T> getEntitiesByBooleanField(Class<T> clazz, String fieldname, Boolean value) {
 
 		Criteria criteria =
-			this.sessionFactory.getCurrentSession().createCriteria(clazz);
+			this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 		criteria.add(Restrictions.eq(fieldname, value));
 
 		// this ensures that no cartesian product is returned when
@@ -864,7 +864,7 @@ public class DatabaseDao {
 		Criteria criteria = null;
 		List<T> returnList = null;
 		try {
-			criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+			criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 			for(Iterator<String> iter = fieldsAndValues.keySet().iterator(); iter.hasNext();) {
 				String fieldname = iter.next();
 				String value = fieldsAndValues.get(fieldname);
@@ -921,7 +921,7 @@ public class DatabaseDao {
 	public List<MapLayer> getOwnedMapLayers(User user) {
 
 		Criteria criteria = this.getSessionFactory().getCurrentSession()
-				.createCriteria(MapLayer.class);
+				.createCriteria(MapLayer.class).setCacheable(true);
 
 		criteria.add(Restrictions.eq("owner", user));
 		// this ensures that no cartesian product is returned when
@@ -1050,7 +1050,7 @@ public class DatabaseDao {
 	 */
 	public void deleteEntityByValue(Class<?> clazz, String column, String value) {
 
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 		criteria.add(Restrictions.eq(column, value));
 		List<Object> records = criteria.list();
 
@@ -1075,7 +1075,7 @@ public class DatabaseDao {
 
 		// get group ID of logged in User and check if there is the
 		// user to be deleted is a child of the current group
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(clazz).setCacheable(true);
 		criteria.add(Restrictions.eq("id", id));
 
 		List<Integer> groupIdsOfSessionUser = this.getGroupIdsFromSession();
@@ -1151,7 +1151,7 @@ public class DatabaseDao {
 
 		try {
 
-			criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class);
+			criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class).setCacheable(true);
 
 			criteria.add(Restrictions.eq("user_name", name));
 
@@ -1188,7 +1188,7 @@ public class DatabaseDao {
 
 		try {
 
-			criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class);
+			criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class).setCacheable(true);
 
 			// add additional restrictions like
 			// where user is in group with ID xy
@@ -1238,7 +1238,7 @@ public class DatabaseDao {
 	public User getUserById(int id, String additionalCriteriaPath, Criterion additionalCriterion) {
 
 		Criteria criteria =
-			this.sessionFactory.getCurrentSession().createCriteria(User.class);
+			this.sessionFactory.getCurrentSession().createCriteria(User.class).setCacheable(true);
 
 		// add additional restrictions like
 		// where user is in group with ID xy
@@ -1349,7 +1349,7 @@ public class DatabaseDao {
 	 */
 	public void deleteUser(int id) throws ShogunDatabaseAccessException {
 
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class).setCacheable(true);
 		criteria.add(Restrictions.eq("id", id));
 		User userToDelete = (User) criteria.uniqueResult();
 
@@ -1390,7 +1390,7 @@ public class DatabaseDao {
 		Criteria criteria = null;
 
 		try {
-			criteria = this.sessionFactory.getCurrentSession().createCriteria(hibernateFilter.getMainClass());
+			criteria = this.sessionFactory.getCurrentSession().createCriteria(hibernateFilter.getMainClass()).setCacheable(true);
 
 		} catch (Exception e) {
 			throw new ShogunDatabaseAccessException(
@@ -1541,7 +1541,7 @@ public class DatabaseDao {
 
 		if (username != null) {
 
-			Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class);
+			Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class).setCacheable(true);
 
 			criteria.setProjection(Projections.property("id"));
 			criteria.add(Restrictions.eq("user_name", username));
@@ -1570,7 +1570,7 @@ public class DatabaseDao {
 		LOGGER.debug("Got authResult: " + authResult.getName());
 		LOGGER.debug("Creating criteria now to get the user.");
 
-		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class);
+		Criteria criteria = this.sessionFactory.getCurrentSession().createCriteria(User.class).setCacheable(true);
 
 		criteria.add(Restrictions.eq("user_name", authResult.getName()));
 
@@ -1595,7 +1595,7 @@ public class DatabaseDao {
 	public boolean hasUserRoleByUsernameAndRolename(String userName, String roleName) {
 		boolean hasRole = false;
 
-		Criteria criteria = this.getSessionFactory().getCurrentSession().createCriteria(User.class);
+		Criteria criteria = this.getSessionFactory().getCurrentSession().createCriteria(User.class).setCacheable(true);
 		criteria.add(Restrictions.eq("user_name", userName));
 		criteria.createCriteria("groups", "g");
 		criteria.createCriteria("g.roles", "r");

--- a/src/main/java/de/terrestris/shogun/model/BaseModel.java
+++ b/src/main/java/de/terrestris/shogun/model/BaseModel.java
@@ -39,6 +39,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -72,6 +73,7 @@ import org.hibernate.annotations.Type;
  *
  */
 @MappedSuperclass
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 @Cacheable
 @Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class BaseModel implements BaseModelInterface {

--- a/src/main/java/de/terrestris/shogun/model/BaseModelInheritance.java
+++ b/src/main/java/de/terrestris/shogun/model/BaseModelInheritance.java
@@ -32,12 +32,9 @@ package de.terrestris.shogun.model;
 
 import java.util.Date;
 
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.MappedSuperclass;
+import javax.persistence.*;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -48,6 +45,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import de.terrestris.shogun.deserializer.DateDeserializer;
 import de.terrestris.shogun.serializer.DateSerializer;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 
 /**
@@ -76,6 +75,9 @@ import org.hibernate.annotations.Type;
  *
  */
 @MappedSuperclass
+@Cacheable
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@Cache(usage= CacheConcurrencyStrategy.READ_WRITE)
 public class BaseModelInheritance implements BaseModelInterface {
 
 	private int id;

--- a/src/main/java/de/terrestris/shogun/model/BaseProxyConfig.java
+++ b/src/main/java/de/terrestris/shogun/model/BaseProxyConfig.java
@@ -49,7 +49,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
  */
 @MappedSuperclass
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class BaseProxyConfig extends BaseModel {
 
 	private String mandatoryParameters;

--- a/src/main/java/de/terrestris/shogun/model/Group.java
+++ b/src/main/java/de/terrestris/shogun/model/Group.java
@@ -76,7 +76,6 @@ import de.terrestris.shogun.serializer.LeanBaseModelSetSerializer;
 @Table(name="TBL_GROUP")
 @Embeddable
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class Group extends BaseModel{
 
 	// TODO refactor as an enum
@@ -398,6 +397,7 @@ public class Group extends BaseModel{
 					nullable = true, updatable = false) })
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
+	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<User> getUsers() {
 		return users;
@@ -420,6 +420,7 @@ public class Group extends BaseModel{
 					nullable = false, updatable = false) })
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
+	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<Module> getModules() {
 		return modules;
@@ -447,6 +448,7 @@ public class Group extends BaseModel{
 	)
 	@Fetch(FetchMode.JOIN)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
+	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<MapLayer> getMapLayers() {
 		return mapLayers;
@@ -478,6 +480,7 @@ public class Group extends BaseModel{
 	)
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
+	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<Role> getRoles() {
 		return roles;

--- a/src/main/java/de/terrestris/shogun/model/LayerMetadata.java
+++ b/src/main/java/de/terrestris/shogun/model/LayerMetadata.java
@@ -58,7 +58,6 @@ import de.terrestris.shogun.model.BaseModel;
 @Table(name="TBL_LAYERMETADATA")
 @Embeddable
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class LayerMetadata extends BaseModel {
 
 	/** the key of this metadata record  **/

--- a/src/main/java/de/terrestris/shogun/model/MapConfig.java
+++ b/src/main/java/de/terrestris/shogun/model/MapConfig.java
@@ -37,6 +37,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -53,11 +54,10 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
  * @author terrestris GmbH & Co. KG
  *
  */
-@JsonAutoDetect
 @Entity
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 @Table(name="TBL_MAPCONFIG")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class MapConfig extends BaseModel {
 
 	public static final String DEFAULT_MAPCONFIG = "default-mapconfig";

--- a/src/main/java/de/terrestris/shogun/model/MapLayer.java
+++ b/src/main/java/de/terrestris/shogun/model/MapLayer.java
@@ -429,7 +429,7 @@ public abstract class MapLayer extends BaseModelInheritance {
 	@OneToMany(fetch = FetchType.LAZY)
 	@Fetch(FetchMode.SUBSELECT)
 	@JoinTable(name="TBL_MAPLAYER_TBL_METADATA")
-    @org.springframework.cache.annotation.Cacheable
+	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<LayerMetadata> getMetadata() {
 		return metadata;
@@ -446,7 +446,6 @@ public abstract class MapLayer extends BaseModelInheritance {
 	 * @return the groups
 	 */
 	@ManyToMany(mappedBy="mapLayers", fetch=FetchType.LAZY)
-//	@JsonIgnore
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
 	@org.springframework.cache.annotation.Cacheable

--- a/src/main/java/de/terrestris/shogun/model/Module.java
+++ b/src/main/java/de/terrestris/shogun/model/Module.java
@@ -54,7 +54,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @Entity
 @Table(name="TBL_MODULE")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class Module extends BaseModel {
 
 

--- a/src/main/java/de/terrestris/shogun/model/OwsProxyConfig.java
+++ b/src/main/java/de/terrestris/shogun/model/OwsProxyConfig.java
@@ -49,7 +49,6 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
  */
 @MappedSuperclass
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class OwsProxyConfig extends BaseProxyConfig {
 
 	private String version;

--- a/src/main/java/de/terrestris/shogun/model/Role.java
+++ b/src/main/java/de/terrestris/shogun/model/Role.java
@@ -56,7 +56,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @Table(name="TBL_ROLE")
 @Embeddable
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class Role extends BaseModel {
 
 	String name;

--- a/src/main/java/de/terrestris/shogun/model/User.java
+++ b/src/main/java/de/terrestris/shogun/model/User.java
@@ -362,7 +362,7 @@ public class User extends BaseModel {
 	@JsonIgnore
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
-    @org.springframework.cache.annotation.Cacheable
+	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<Group> getGroups() {
 		return groups;

--- a/src/main/java/de/terrestris/shogun/model/User.java
+++ b/src/main/java/de/terrestris/shogun/model/User.java
@@ -71,7 +71,6 @@ import de.terrestris.shogun.serializer.LeanBaseModelSetSerializer;
 @Table(name="TBL_USER")
 @Embeddable
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class User extends BaseModel {
 
 	private String user_name;
@@ -359,10 +358,11 @@ public class User extends BaseModel {
 	/**
 	 * @return the groups
 	 */
-	@ManyToMany(mappedBy = "users", fetch = FetchType.EAGER)
+	@ManyToMany(mappedBy = "users", fetch = FetchType.LAZY)
 	@JsonIgnore
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
+    @org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<Group> getGroups() {
 		return groups;
@@ -378,7 +378,10 @@ public class User extends BaseModel {
 	/**
 	 * @return the mapConfig
 	 */
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
+	@Fetch(FetchMode.SELECT)
+	@org.springframework.cache.annotation.Cacheable
+	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public MapConfig getMapConfig() {
 		return mapConfig;
 	}
@@ -394,8 +397,11 @@ public class User extends BaseModel {
 	/**
 	 * @return the wfsProxyConfig
 	 */
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
+	@Fetch(FetchMode.SELECT)
 	@JsonIgnore // needed that this is not serialized, hidden to client (security)
+	@org.springframework.cache.annotation.Cacheable
+	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public WfsProxyConfig getWfsProxyConfig() {
 		return wfsProxyConfig;
 	}
@@ -412,8 +418,11 @@ public class User extends BaseModel {
 	/**
 	 * @return the wmsProxyConfig
 	 */
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
+	@Fetch(FetchMode.SELECT)
 	@JsonIgnore // needed that this is not serialized, hidden to client (security)
+	@org.springframework.cache.annotation.Cacheable
+	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public WmsProxyConfig getWmsProxyConfig() {
 		return wmsProxyConfig;
 	}

--- a/src/main/java/de/terrestris/shogun/model/WfsProxyConfig.java
+++ b/src/main/java/de/terrestris/shogun/model/WfsProxyConfig.java
@@ -54,7 +54,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @Entity
 @Table(name="TBL_WFSPROXYCONFIG")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class WfsProxyConfig extends OwsProxyConfig {
 
 	private String typename;

--- a/src/main/java/de/terrestris/shogun/model/Wms.java
+++ b/src/main/java/de/terrestris/shogun/model/Wms.java
@@ -64,7 +64,6 @@ import de.terrestris.shogun.serializer.LeanBaseModelSetSerializer;
 @Entity
 @Table(name="TBL_WMS")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class Wms extends BaseModel {
 
 	private String supportedVersion;
@@ -149,6 +148,8 @@ public class Wms extends BaseModel {
 	@OneToMany(fetch = FetchType.LAZY, targetEntity=WmsLayer.class)
 	@Fetch(FetchMode.SUBSELECT)
 	@JsonSerialize(using=LeanBaseModelSetSerializer.class)
+	@org.springframework.cache.annotation.Cacheable
+	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 	public Set<WmsLayer> getWmsLayers() {
 		return wmsLayers;
 	}

--- a/src/main/java/de/terrestris/shogun/model/WmsLayer.java
+++ b/src/main/java/de/terrestris/shogun/model/WmsLayer.java
@@ -54,7 +54,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @Entity
 @Table(name="TBL_WMSLAYER")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class WmsLayer extends BaseModel {
 
 	/**

--- a/src/main/java/de/terrestris/shogun/model/WmsMapLayer.java
+++ b/src/main/java/de/terrestris/shogun/model/WmsMapLayer.java
@@ -30,10 +30,7 @@
  */
 package de.terrestris.shogun.model;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -57,7 +54,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @Entity
 @Table(name="TBL_WMSMAPLAYER")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class WmsMapLayer extends MapLayer {
 
 	private String url;

--- a/src/main/java/de/terrestris/shogun/model/WmsProxyConfig.java
+++ b/src/main/java/de/terrestris/shogun/model/WmsProxyConfig.java
@@ -54,7 +54,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 @Entity
 @Table(name="TBL_WMSPROXYCONFIG")
 @Cacheable
-@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
 public class WmsProxyConfig extends OwsProxyConfig {
 
 	private String layers;


### PR DESCRIPTION
* Enables caching for all `critera` objects
* Removes `CacheConcurrencyStrategy` from classes as this will be inherited from superclass
* Enables caching for all collections