### PR TITLE
Use List instead of Set to store metadata objects

### DIFF
--- a/src/main/java/de/terrestris/shogun/model/LayerMetadata.java
+++ b/src/main/java/de/terrestris/shogun/model/LayerMetadata.java
@@ -30,22 +30,13 @@
  */
 package de.terrestris.shogun.model;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-
-import de.terrestris.shogun.model.BaseModel;
+import javax.persistence.*;
 
 /**
  * LayerMetadata POJO

--- a/src/main/java/de/terrestris/shogun/model/MapLayer.java
+++ b/src/main/java/de/terrestris/shogun/model/MapLayer.java
@@ -428,7 +428,7 @@ public abstract class MapLayer extends BaseModelInheritance {
 	 * @return the metadata
 	 */
 	@OneToMany(fetch = FetchType.EAGER)
-	@Fetch(FetchMode.SUBSELECT)
+	@Fetch(FetchMode.JOIN)
 	@JoinTable(name="TBL_MAPLAYER_TBL_METADATA")
 	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)

--- a/src/main/java/de/terrestris/shogun/model/MapLayer.java
+++ b/src/main/java/de/terrestris/shogun/model/MapLayer.java
@@ -30,6 +30,7 @@
  */
 package de.terrestris.shogun.model;
 
+import java.util.List;
 import java.util.Set;
 
 import javax.persistence.*;
@@ -92,7 +93,7 @@ public abstract class MapLayer extends BaseModelInheritance {
 	private Boolean displayOutsideMaxExtent = false;
 	private String transitionEffect = null;
 
-	private Set<LayerMetadata> metadata;
+	private List<LayerMetadata> metadata;
 	private Set<Group> groups;
 
 	/**
@@ -431,14 +432,14 @@ public abstract class MapLayer extends BaseModelInheritance {
 	@JoinTable(name="TBL_MAPLAYER_TBL_METADATA")
 	@org.springframework.cache.annotation.Cacheable
 	@Cache(usage=CacheConcurrencyStrategy.READ_WRITE)
-	public Set<LayerMetadata> getMetadata() {
+	public List<LayerMetadata> getMetadata() {
 		return metadata;
 	}
 
 	/**
 	 * @param metadata the metadata to set
 	 */
-	public void setMetadata(Set<LayerMetadata> metadata) {
+	public void setMetadata(List<LayerMetadata> metadata) {
 		this.metadata = metadata;
 	}
 


### PR DESCRIPTION
* Make use of `java.util.List` in favour of `java.util.Set` to store the metadata entites
  *   This way we can better catch the exception which can possibly occure if we fetching more than one collection at a time (`MultipleBagFetchException`)
* Switch to fetch mode `JOIN` in favour of `SUBSELECT` as it better acts with `FetchType.EAGER` strategy.

Please review @terrestris/devs 
  